### PR TITLE
tar.bz -> tar.bz2

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The filename you upload should match the distribution name and version, e.g.
     Your-Module-v1.23.tar.gz
     Your-Module-v1.23.zip
 
-`tgz` and `tar.bz` might also work.
+`tgz` and `tar.bz2` might also work.
 
 The archive should unpack to `Your-Module-version`. Do not omit the version.
 If people unpack different versions of your module, they should not end up


### PR DESCRIPTION
At least, cpanm needs the suffix `tar.bz2` for bzip2 compression.
https://github.com/miyagawa/cpanminus/blob/7b574ede70cebce3709743ec1727f90d745e8580/Menlo-Legacy/lib/Menlo/CLI/Compat.pm#L2767